### PR TITLE
Fix missing iso codes

### DIFF
--- a/rgeo.go
+++ b/rgeo.go
@@ -256,8 +256,8 @@ func getLocationStrings(p map[string]interface{}) Location {
 	return Location{
 		Country:      getPropertyString(p, "ADMIN", "admin"),
 		CountryLong:  getPropertyString(p, "FORMAL_EN"),
-		CountryCode2: getPropertyString(p, "ISO_A2"),
-		CountryCode3: getPropertyString(p, "ISO_A3"),
+		CountryCode2: getPropertyString(p, "ISO_A2_EH"),
+		CountryCode3: getPropertyString(p, "ISO_A3_EH"),
 		Continent:    getPropertyString(p, "CONTINENT"),
 		Region:       getPropertyString(p, "REGION_UN"),
 		SubRegion:    getPropertyString(p, "SUBREGION"),

--- a/rgeo_test.go
+++ b/rgeo_test.go
@@ -215,7 +215,7 @@ func TestReverseGeocode(t *testing.T) {
 		"type":"FeatureCollection",
 			"features":[
 				{"type":"Feature",
-				"properties":{"ISO_A3":"TST"},
+				"properties":{"ISO_A3_EH":"TST"},
 				"geometry":{"type":"Polygon",
 					"coordinates":[[[0,52],[1,52],[1,53],[0,53],[0,52]]]}}
 			]


### PR DESCRIPTION
[The original Issue](https://github.com/nvkelso/natural-earth-vector/issues/284) was that some countries (e.g. France, Norway, ...) had their ISO-3166-1 country codes set to `-99`.

 This [was addressed](https://github.com/nvkelso/natural-earth-vector/pull/446) in then version `5.1.2`, but not by updating the field `ISO_A2` to the correct value (as assumed), but rather setting the correct value in the field `ISO_A2_EH` ([reference](https://github.com/nvkelso/natural-earth-vector/issues/675)).

Thus, updating the dataset was not sufficient and this PR is needed to read from the correct field in rgeo lookups.